### PR TITLE
Add `--access` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ $ filewatcher --restart --immediate "**/*.html" "python -m SimpleHTTPServer"
 
 The `--daemon/-D` option starts filewatcher in the background as system daemon, so filewatcher will not be terminated by `Ctrl+C`, for example.
 
+## Watch for files access (read) events
+
+The `--access/-a` option will add to changes files,
+that have changed the `atime` property, with the `:readed` event,
+and the command (or block of code) will be executed on these events.
+
 ## Available enviroment variables
 
 The environment variable $FILENAME is available in the shell command argument.
@@ -154,7 +160,8 @@ BASENAME           File basename.
 FILENAME           Relative filename.
 ABSOLUTE_FILENAME  Asolute filename.
 RELATIVE_FILENAME  Same as FILENAME but starts with "./"
-EVENT              Event type. Is either 'updated', 'deleted' or 'created'.
+EVENT              Event type. Is either 'updated', 'deleted', 'created'
+                   or `readed` (with `access` option).
 DIRNAME            Absolute directory name.
 ```
 
@@ -166,6 +173,7 @@ Useful command line options:
         --list, -l:   Print name of matching files on startup
      --restart, -r:   Run command in separate fork and kill it on filesystem updates
    --immediate, -I:   Run the command before any filesystem updates
+      --access, -a:   Run the command for files that were accessed (readed)
        --every, -E:   Run the command for every updated file in one filesystem check
       --daemon, -D:   Run in the background as system daemon
      --spinner, -s:   Display an animated spinner while scanning
@@ -319,7 +327,7 @@ This project would not be where it is today without the generous help provided b
 
 *   [Kristoffer Roupé](https://github.com/kitofr): Command line globbing
 
-*   [Alexander Popov](https://github.com/AlexWayfer): Daemon mode, many small fixes and improvements
+*   [Alexander Popov](https://github.com/AlexWayfer): Daemon mode, `--access` option, and many fixes and improvements
 
 This gem was initially inspired by [Tom Lieber's blogg posting](http://alltom.com/pages/detecting-file-changes-with-ruby) ([Web Archive version](http://web.archive.org/web/20120208094934/http://alltom.com/pages/detecting-file-changes-with-ruby)).
 

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -29,6 +29,8 @@ options = Trollop.options do
       type: :string, default: nil
   opt :interval, 'Interval to scan filesystem',
       short: 'i', type: :float, default: 0.5
+  opt :access, 'Watch for file access (read) events',
+      short: 'a', type: :boolean, default: false
   opt :spinner, 'Show an ascii spinner',
       short: 's', type: :boolean, default: false
 end

--- a/lib/filewatcher/cycles.rb
+++ b/lib/filewatcher/cycles.rb
@@ -7,7 +7,7 @@ class Filewatcher
 
     def main_cycle
       while @keep_watching
-        @end_snapshot = mtime_snapshot if @pausing
+        @end_snapshot = current_snapshot if @pausing
 
         pausing_cycle
 

--- a/lib/filewatcher/snapshot.rb
+++ b/lib/filewatcher/snapshot.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+class Filewatcher
+  # Class for snapshots of filesystem
+  class Snapshot
+    extend Forwardable
+    def_delegators :@data, :[], :each, :keys
+
+    def initialize(filenames)
+      @data = filenames.each_with_object({}) do |filename, data|
+        data[filename] = SnapshotFile.new(filename)
+      end
+    end
+
+    def -(other)
+      changes = {}
+
+      each do |filename, snapshot_file|
+        changes[filename] = snapshot_file - other[filename]
+      end
+
+      other.each do |filename, _snapshot_file|
+        changes[filename] = :deleted unless self[filename]
+      end
+
+      changes.reject! { |_filename, event| event.nil? }
+      changes
+    end
+
+    # Class for one file from snapshot
+    class SnapshotFile
+      STATS = %i[mtime atime].freeze
+
+      attr_reader(*STATS)
+
+      def initialize(filename)
+        @filename = filename
+        STATS.each do |stat|
+          time = File.public_send(stat, filename) if File.exist?(filename)
+          instance_variable_set :"@#{stat}", time || Time.new(0)
+        end
+      end
+
+      def -(other)
+        if other.nil?
+          :created
+        elsif other.mtime < mtime
+          :updated
+        elsif other.atime < atime
+          :readed
+        end
+      end
+    end
+
+    private_constant :SnapshotFile
+  end
+end

--- a/test/filewatcher/test_snapshot.rb
+++ b/test/filewatcher/test_snapshot.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/filewatcher/snapshot'
+
+describe Filewatcher::Snapshot do
+  before do
+    @times = 4
+    @files = (1..@times).map do |n|
+      File.join(WatchRun::TMP_DIR, "file#{n}.txt")
+    end
+
+    FileUtils.mkdir_p WatchRun::TMP_DIR
+
+    @files.each_with_index do |file, n|
+      File.write file, "content#{n}"
+    end
+
+    @init = proc do
+      Filewatcher::Snapshot.new Dir[
+        File.join(WatchRun::TMP_DIR, '**', '*')
+      ]
+    end
+  end
+
+  after do
+    FileUtils.rm_r WatchRun::TMP_DIR
+  end
+
+  describe '#initialize' do
+    it 'should take snapshot of current filesystem state' do
+      snapshot = @init.call
+
+      snapshot.each do |filename, snapshot_file|
+        snapshot_file.mtime.should.equal File.mtime(filename)
+        snapshot_file.atime.should.equal File.atime(filename)
+      end
+    end
+  end
+
+  describe '#-' do
+    it 'should return hash with filename => event' do
+      first_snapshot = @init.call
+
+      sleep 0.1
+
+      File.write @files[1], 'new content'
+      File.read @files[2]
+      File.delete @files[3]
+      new_file = File.join(WatchRun::TMP_DIR, 'file5.txt')
+      File.write(new_file, 'new file')
+
+      second_snapshot = @init.call
+
+      (second_snapshot - first_snapshot).should.equal(
+        @files[1] => :updated,
+        @files[2] => :readed,
+        @files[3] => :deleted,
+        new_file => :created
+      )
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,9 +51,7 @@ class WatchRun
 
   def thread_initialize
     @watched ||= 0
-    Thread.new(
-      @filewatcher, @processed = []
-    ) do |filewatcher, processed|
+    Thread.new(@filewatcher, @processed = []) do |filewatcher, processed|
       filewatcher.watch do |changes|
         increment_watched
         processed.concat(changes.keys)
@@ -67,6 +65,7 @@ class WatchRun
 
   def make_changes
     return FileUtils.remove(@filename) if @action == :delete
+    return File.read(@filename) if @action == :access
     return FileUtils.mkdir_p(@filename) if @directory
     File.write(@filename, 'content2')
   end

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -153,6 +153,28 @@ describe Filewatcher do
 
       wr.processed.should.be.any
     end
+
+    it 'should detect file access (read) with option' do
+      wr = WatchRun.new(
+        filewatcher: Filewatcher.new('**/*', access: true),
+        action: :access
+      )
+
+      wr.run
+
+      wr.processed.should.be.any
+    end
+
+    it 'should not detect file access (read) without access option' do
+      wr = WatchRun.new(
+        filewatcher: Filewatcher.new('**/*', access: false),
+        action: :access
+      )
+
+      wr.run
+
+      wr.processed.should.be.empty
+    end
   end
 
   describe '#stop' do


### PR DESCRIPTION
This option allows the command (or block of code) be executed when watching files were accessed (readed).

Resolve #55