### PR TITLE
Fix copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009 - 2014 Thomas Flemming
+Copyright (c) 2010 - 2018 Thomas Flemming
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -337,4 +337,4 @@ This gem was initially inspired by [Tom Lieber's blogg posting](http://alltom.co
 
 ## Copyright
 
-Copyright (c) 2011 - 2017 Thomas Flemming. See LICENSE for details.
+Copyright (c) 2010 - 2018 Thomas Flemming. See LICENSE for details.


### PR DESCRIPTION
Repo haves `2009` in one place and `2011` in another.

But I found the first commit (without code) as 9ea5ecdba7c68190588a8108798cee947e9919fa from Jan 25, 2010. And initial release as eeff7d9939214450b2357a957e82cf4fcf902ae2 from the same day. Even `LICENSE` file with `2009` created in this day in 3da7563672bbb09d3bcd08ff632a4b91e4b9016c.

@thomasfl, am I right?