### PR TITLE
Batch changes (and remove `options[:every]`)

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -80,25 +80,29 @@ begin
 
   Process.daemon(true, true) if options[:daemon]
 
-  fw.watch do |filename, event|
-    cmd =
-      if options[:exec] && File.exist?(filename)
-        Filewatcher::Runner.new(filename).command
-      elsif ARGV.length > 1
-        ARGV[-1]
-      end
+  fw.watch do |changes|
+    changes = options[:every] ? changes : changes.first(1)
 
-    next puts "file #{event}: #{filename}" unless cmd
+    changes.each do |filename, event|
+      cmd =
+        if options[:exec] && File.exist?(filename)
+          Filewatcher::Runner.new(filename).command
+        elsif ARGV.length > 1
+          ARGV[-1]
+        end
 
-    env = Filewatcher::Env.new(filename, event).to_h
-    if options[:restart]
-      child_pid = restart(child_pid, env, cmd)
-    else
-      begin
-        Process.spawn(env, cmd)
-        Process.wait
-      rescue SystemExit, Interrupt
-        exit(0)
+      next puts "file #{event}: #{filename}" unless cmd
+
+      env = Filewatcher::Env.new(filename, event).to_h
+      if options[:restart]
+        child_pid = restart(child_pid, env, cmd)
+      else
+        begin
+          Process.spawn(env, cmd)
+          Process.wait
+        rescue SystemExit, Interrupt
+          exit(0)
+        end
       end
     end
   end

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -29,7 +29,6 @@ class Filewatcher
     @immediate = options[:immediate]
     @show_spinner = options[:spinner]
     @interval = options.fetch(:interval, 0.5)
-    @every = options[:every]
     @logger = options.fetch(:logger, Logger.new($stdout))
   end
 
@@ -42,7 +41,7 @@ class Filewatcher
 
     @on_update = on_update
     @keep_watching = true
-    yield('', '') if @immediate
+    yield({ '' => '' }) if @immediate
 
     main_cycle
 

--- a/lib/filewatcher/cycles.rb
+++ b/lib/filewatcher/cycles.rb
@@ -38,10 +38,7 @@ class Filewatcher
 
     def trigger_changes(on_update = @on_update)
       debug __method__
-      changes = @every ? @changes : @changes.first(1)
-      changes.each do |filename, event|
-        on_update.call(filename, event)
-      end
+      on_update.call(@changes.dup)
       @changes.clear
       debug '@changes cleared'
     end

--- a/lib/filewatcher/cycles.rb
+++ b/lib/filewatcher/cycles.rb
@@ -38,7 +38,7 @@ class Filewatcher
 
     def trigger_changes(on_update = @on_update)
       debug __method__
-      on_update.call(@changes.dup)
+      on_update.call(@changes.dup) unless @changes.empty?
       @changes.clear
       debug '@changes cleared'
     end

--- a/spec/filewatcher_spec.rb
+++ b/spec/filewatcher_spec.rb
@@ -42,7 +42,7 @@ describe Filewatcher do
     )
   end
 
-  let(:processed_files) { watch_run.processed.map(&:first) }
+  let(:processed_files) { watch_run.processed.map(&:keys) }
 
   describe '#initialize' do
     describe 'regular run' do
@@ -66,25 +66,25 @@ describe Filewatcher do
           )
         end
 
-        it { is_expected.to eq [[watch_run.filename, :updated]] }
+        it { is_expected.to eq [{ watch_run.filename => :updated }] }
       end
 
       context 'with globs' do
         let(:filewatcher) { initialize_filewatcher('spec/tmp/**/*') }
 
-        it { is_expected.to eq [[watch_run.filename, :updated]] }
+        it { is_expected.to eq [{ watch_run.filename => :updated }] }
       end
 
       context 'with explicit relative paths with globs' do
         let(:filewatcher) { initialize_filewatcher('./spec/tmp/**/*') }
 
-        it { is_expected.to eq [[watch_run.filename, :updated]] }
+        it { is_expected.to eq [{ watch_run.filename => :updated }] }
       end
 
       context 'with explicit relative paths' do
         let(:filewatcher) { initialize_filewatcher('./spec/tmp') }
 
-        it { is_expected.to eq [[watch_run.filename, :updated]] }
+        it { is_expected.to eq [{ watch_run.filename => :updated }] }
       end
 
       context 'with tilde expansion' do
@@ -92,7 +92,7 @@ describe Filewatcher do
 
         let(:filewatcher) { initialize_filewatcher('~/file_watcher_1.txt') }
 
-        it { is_expected.to eq [[filename, :updated]] }
+        it { is_expected.to eq [{ filename => :updated }] }
       end
     end
 
@@ -105,7 +105,7 @@ describe Filewatcher do
       context 'when is `true`' do
         let(:immediate) { true }
 
-        it { is_expected.to eq [['', '']] }
+        it { is_expected.to eq [{ '' => '' }] }
 
         describe 'when watched' do
           subject { watch_run.watched }
@@ -138,19 +138,19 @@ describe Filewatcher do
     describe 'detecting file deletions' do
       let(:action) { :delete }
 
-      it { is_expected.to eq [[watch_run.filename, :deleted]] }
+      it { is_expected.to eq [{ watch_run.filename => :deleted }] }
     end
 
     context 'when there are file additions' do
       let(:action) { :create }
 
-      it { is_expected.to eq [[watch_run.filename, :created]] }
+      it { is_expected.to eq [{ watch_run.filename => :created }] }
     end
 
     context 'when there are file updates' do
       let(:action) { :update }
 
-      it { is_expected.to eq [[watch_run.filename, :updated]] }
+      it { is_expected.to eq [{ watch_run.filename => :updated }] }
     end
 
     context 'when there are new files in subdirectories' do
@@ -162,7 +162,7 @@ describe Filewatcher do
 
       it do
         expect(processed).to eq [
-          [subdirectory, :updated], [watch_run.filename, :created]
+          { subdirectory => :updated, watch_run.filename => :created }
         ]
       end
     end
@@ -172,7 +172,7 @@ describe Filewatcher do
       let(:directory) { true }
       let(:action) { :create }
 
-      it { is_expected.to eq [[watch_run.filename, :created]] }
+      it { is_expected.to eq [{ watch_run.filename => :created }] }
     end
   end
 

--- a/spec/filewatcher_spec.rb
+++ b/spec/filewatcher_spec.rb
@@ -28,10 +28,11 @@ describe Filewatcher do
   let(:directory) { false }
   let(:every) { false }
   let(:immediate) { false }
+  let(:interval) { 0.2 }
   let(:filewatcher) do
     initialize_filewatcher(
       File.join(WatchRun::TMP_DIR, '**', '*'),
-      interval: 0.2, every: every, immediate: immediate
+      interval: interval, every: every, immediate: immediate
     )
   end
 
@@ -159,6 +160,8 @@ describe Filewatcher do
       let(:filename) { File.join(subdirectory, 'file.txt') }
       let(:action) { :create }
       let(:every) { true }
+      ## https://github.com/filewatcher/filewatcher/pull/115#issuecomment-674581595
+      let(:interval) { 0.4 }
 
       it do
         expect(processed).to eq [

--- a/spec/filewatcher_spec.rb
+++ b/spec/filewatcher_spec.rb
@@ -42,7 +42,7 @@ describe Filewatcher do
     )
   end
 
-  let(:processed_files) { watch_run.processed.map(&:keys) }
+  let(:processed_files) { watch_run.processed.flat_map(&:keys) }
 
   describe '#initialize' do
     describe 'regular run' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -169,12 +169,12 @@ class RubyWatchRun < WatchRun
   def setup_filewatcher
     debug 'setup_filewatcher'
     debug filewatcher.inspect
-    filewatcher.watch do |filename, event|
+    filewatcher.watch do |changes|
       debug filewatcher.inspect
       @mutex.synchronize do
-        debug "watch callback: filename = #{filename}, event = #{event}"
+        debug "watch callback: changes = #{changes.inspect}"
         increment_watched
-        @processed.push([filename, event])
+        @processed.push(changes)
         # debug 'pushed to processed'
       end
     end


### PR DESCRIPTION
```
This removes the `every` option when initializing Filewatcher.

Though backwards incompatible, it's fairly simple to emulate the
previous behavior.

    filewatcher.watch do |changes|
      # to emulate every=true
      changes.each do |filename, event|
        # ...
      end

      # to emulate every=false
      filename, event = changes.first
      # ...
    end
```

The CLI option `--every` remains unchanged.