### PR TITLE
Replace `KILL` signal with `TERM` for `:restart` option

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -54,7 +54,7 @@ def restart(pid, env, cmd)
   begin
     raise Errno::ESRCH unless pid
 
-    Process.kill(9, pid)
+    Process.kill('TERM', pid)
     Process.wait(pid)
   rescue Errno::ESRCH
     nil # already killed


### PR DESCRIPTION
I don't see needing for `KILL` signal, also we're waiting for termination.

Resolve #106