### PR TITLE
Improve system `stat` command

### DIFF
--- a/lib/filewatcher/snapshots.rb
+++ b/lib/filewatcher/snapshots.rb
@@ -32,10 +32,19 @@ class Filewatcher
       return Time.new(0) unless File.exist?(filename)
 
       result = File.mtime(filename)
-      @logger.debug "File.mtime = #{result.inspect}"
-      @logger.debug "stat #{filename}:"
-      system "stat #{filename}"
+      if @logger.level <= Logger::DEBUG
+        @logger.debug "File.mtime = #{result.inspect}"
+        @logger.debug "stat #{filename}: #{system_stat(filename)}"
+      end
       result
+    end
+
+    def system_stat(filename)
+      case Gem::Platform.local.os
+      when 'linux' then `stat --printf 'Modification: %y, Change: %z\n' #{filename}`
+      when 'darwin' then `stat #{filename}`
+      else 'Unknown OS for system `stat`'
+      end
     end
 
     def filesystem_updated?(snapshot = mtime_snapshot)


### PR DESCRIPTION
1.  Use only in macOS and Linux,
    but I don't see a possibility to display milliseconds in macOS.
2.  Don't execute this command unless there is the `debug` logging level.