### PR TITLE
Sleep before trigger changes

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -73,7 +73,7 @@ begin
 
   if options[:list]
     puts 'Watching:'
-    fw.last_found_filenames.each do |filename|
+    fw.found_filenames.each do |filename|
       puts " #{filename}"
     end
   end

--- a/lib/filewatcher/cycles.rb
+++ b/lib/filewatcher/cycles.rb
@@ -27,10 +27,13 @@ class Filewatcher
     end
 
     def watching_cycle
-      while @keep_watching && !filesystem_updated? && !@pausing
+      @logger.debug __method__
+      @last_snapshot ||= mtime_snapshot
+      loop do
         update_spinner('Watching')
         @logger.debug "#{__method__} sleep #{@interval}"
         sleep @interval
+        break if !@keep_watching || filesystem_updated? || @pausing
       end
     end
 

--- a/lib/filewatcher/snapshots.rb
+++ b/lib/filewatcher/snapshots.rb
@@ -3,15 +3,11 @@
 class Filewatcher
   # Module for snapshot logic inside Filewatcher
   module Snapshots
-    def last_found_filenames
-      last_snapshot.keys
+    def found_filenames
+      mtime_snapshot.keys
     end
 
     private
-
-    def last_snapshot
-      @last_snapshot ||= mtime_snapshot
-    end
 
     # Takes a snapshot of the current status of watched files.
     # (Allows avoidance of potential race condition during #finalize)
@@ -50,11 +46,11 @@ class Filewatcher
     def filesystem_updated?(snapshot = mtime_snapshot)
       @changes = {}
 
-      (snapshot.to_a - last_snapshot.to_a).each do |file, _mtime|
-        @changes[file] = last_snapshot[file] ? :updated : :created
+      (snapshot.to_a - @last_snapshot.to_a).each do |file, _mtime|
+        @changes[file] = @last_snapshot[file] ? :updated : :created
       end
 
-      (last_snapshot.keys - snapshot.keys).each do |file|
+      (@last_snapshot.keys - snapshot.keys).each do |file|
         @changes[file] = :deleted
       end
 


### PR DESCRIPTION
It prevents multiple triggers for changes done one by one in microseconds.

May help for strange cases in CI when `mtime` of test file changes somewhy
by microseconds, example: https://cirrus-ci.com/task/6094408330248192?command=test#L156

Also may affect behavior for switching git branches with a large difference
while Filewatcher running.