### PR TITLE
Move JRuby warnings in README.md file to bottom of the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ Needs Ruby and RubyGems:
 $ [sudo] gem install filewatcher
 ```
 
-## Usage warning
-
-JRuby with version < `9.1.9.0` doesn't provide milliseconds of `File.mtime`, as MRI does.
-So be careful with `--interval` less than 1 second.
-
-[Issue](https://github.com/jruby/jruby/issues/4520).
-
 ## Command line utility
 
 Filewatcher scans the file system and execute a shell command when files are
@@ -317,6 +310,13 @@ Filewatcher.new(['**/*.*']).watch do |filename, event|
   puts "Relative filename: #{File.join('.', path)}"
   puts "Absolute filename: #{path.realpath}"
 end
+
+## Usage warning
+
+JRuby with version < `9.1.9.0` doesn't provide milliseconds of `File.mtime`, as MRI does.
+So be careful with `--interval` less than 1 second.
+
+[Issue](https://github.com/jruby/jruby/issues/4520).
 ```
 
 ## Changelog


### PR DESCRIPTION
The warning about JRuby problems has become very much outdated, and can at least be pushed to the bottom of the readme. Can also be considered to be removed totally.