### PR TITLE
Switch Homebrew installation (for CI) from Ruby to Bash

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,7 +63,7 @@ test_task:
         PATH: "/usr/local/opt/ruby/bin:$PATH"
       <<: *unix_bundle_cache
       install_script:
-        - ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        - bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
         - brew install ruby
         ## https://github.com/rubygems/rubygems/issues/2058#issuecomment-342347290
         - gem install bundler --force


### PR DESCRIPTION
> Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
> Bash. Please migrate to the following command:
> ```bash
> /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
> ```

https://cirrus-ci.com/task/5164853973221376?command=install#L2-L4