### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ filewatcher.resume      # block begins responding again, but is not given
                         # changes made between #pause_watch and
                         # #resume_watch
 # ...
-filewatcher.end         # block stops responding to file system changes
+filewatcher.stop        # block stops responding to file system changes
                         # and takes a final snapshot of the file system
 thread.join
 


### PR DESCRIPTION
Since `end` is a reserved word, I think the documentation meant to refer to the `.stop` method