### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -45,7 +45,6 @@ test_task:
   matrix:
     - container:
         matrix:
-          image: ruby:2.4
           image: ruby:2.5
           image: ruby:2.6
           image: ruby:2.7

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,7 +31,7 @@ Metrics/BlockLength:
     - spec/**/*.rb
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: enable
 
 RSpec/NestedGroups:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     Take out [CLI](https://github.com/filewatcher/filewatcher-cli)
     and [spinner](https://github.com/filewatcher/filewatcher-spinner).
 *   Remove `:every` option: do it yourself via `changes.first`, if you want.
+*   Drop Ruby 2.4 support.
 *   Support Ruby 3.
 *   Switch from `bacon` test framework to RSpec.
     Speed up and improve tests, fix many phantom fails.

--- a/filewatcher.gemspec
+++ b/filewatcher.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.required_ruby_version = '>= 2.4', '< 4'
+  s.required_ruby_version = '>= 2.5', '< 4'
 
   s.add_development_dependency 'bundler', '~> 2.0'
 


### PR DESCRIPTION
Its life has ended: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/

Also `gem_toys` requires `>= 2.5` (I don't know why, but I'm sure there is a reason).