### PR TITLE
Fix `stat` for JRuby

### DIFF
--- a/lib/filewatcher/snapshots.rb
+++ b/lib/filewatcher/snapshots.rb
@@ -4,16 +4,6 @@ require_relative 'snapshot'
 
 # Helpers in Filewatcher class itself
 class Filewatcher
-  class << self
-    def system_stat(filename)
-      case Gem::Platform.local.os
-      when 'linux' then `stat --printf 'Modification: %y, Change: %z\n' #{filename}`
-      when 'darwin' then `stat #{filename}`
-      else 'Unknown OS for system `stat`'
-      end
-    end
-  end
-
   # Module for snapshot logic inside Filewatcher
   module Snapshots
     def found_filenames

--- a/lib/filewatcher/spec_helper.rb
+++ b/lib/filewatcher/spec_helper.rb
@@ -59,5 +59,13 @@ class Filewatcher
     def debug(string)
       logger.debug "Thread ##{Thread.current.object_id} #{string}"
     end
+
+    def system_stat(filename)
+      case (host_os = RbConfig::CONFIG['host_os'])
+      when 'linux' then `stat --printf 'Modification: %y, Change: %z\n' #{filename}`
+      when /darwin\d*/ then `stat #{filename}`
+      else "Unknown OS `#{host_os}` for system's `stat` command"
+      end
+    end
   end
 end

--- a/lib/filewatcher/spec_helper/watch_run.rb
+++ b/lib/filewatcher/spec_helper/watch_run.rb
@@ -10,7 +10,7 @@ class Filewatcher
 
       TMP_DIR = "#{Dir.getwd}/spec/tmp"
 
-      def_delegators Filewatcher::SpecHelper, :debug, :wait
+      def_delegators Filewatcher::SpecHelper, :debug, :wait, :system_stat
 
       attr_reader :filename
 
@@ -68,7 +68,7 @@ class Filewatcher
       end
 
       def debug_file_mtime
-        debug "stat #{@filename}: #{Filewatcher.system_stat(@filename)}"
+        debug "stat #{@filename}: #{system_stat(@filename)}"
         debug "File.mtime = #{File.mtime(@filename).strftime('%F %T.%9N')}"
       end
     end


### PR DESCRIPTION
Previous method returns `java` on any OS.

Current method can return `darwin19`, so I use Regexp here.

Also move `system_stat` method from `Filewatcher` to `SpecHelper`.