### PR TITLE
Suppress Bundle warnings

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -10,6 +10,15 @@ unix_bundle_cache: &unix_bundle_cache
     - bundle config set --local path 'vendor/bundle'
     - bundle update
 
+env:
+  ## To suppress flood of warnings:
+  ## https://github.com/cirruslabs/cirrus-ci-docs/issues/814
+  ## https://github.com/rubygems/rubygems/issues/4466#issuecomment-818688569
+  ## Global for:
+  ## 1. different tasks (rubocop, test, etc.);
+  ## 2. avoiding overriding `env` in specific cases like macOS.
+  TMPDIR: $CIRRUS_WORKING_DIR
+
 remark_task:
   container:
     image: node


### PR DESCRIPTION
Open issue for CI: https://github.com/cirruslabs/cirrus-ci-docs/issues/814

This is work-around from Bundler: https://github.com/rubygems/rubygems/issues/4466#issuecomment-818688569