### PR TITLE
Return `extend self` instead of `module_function`

### DIFF
--- a/lib/filewatcher/spec_helper.rb
+++ b/lib/filewatcher/spec_helper.rb
@@ -13,18 +13,18 @@ require_relative 'spec_helper/watch_run'
 class Filewatcher
   ## Helper for common spec features between plugins
   module SpecHelper
-    module_function
+    ENVIRONMENT_SPECS_COEFFICIENTS = {
+      -> { ENV['CI'] } => 1,
+      -> { RUBY_PLATFORM == 'java' } => 1,
+      -> { Gem::Platform.local.os == 'darwin' } => 1
+    }.freeze
 
     def logger
       @logger ||= Logger.new($stdout, level: :debug)
     end
 
     def environment_specs_coefficients
-      @environment_specs_coefficients ||= {
-        -> { ENV['CI'] } => 1,
-        -> { RUBY_PLATFORM == 'java' } => 1,
-        -> { Gem::Platform.local.os == 'darwin' } => 1
-      }
+      ENVIRONMENT_SPECS_COEFFICIENTS
     end
 
     def wait(seconds: 1, interval: 1, &block)
@@ -80,5 +80,10 @@ class Filewatcher
       # debug command
       `#{command}`
     end
+
+    ## https://github.com/rubocop/ruby-style-guide/issues/556#issuecomment-828672008
+    # rubocop:disable Style/ModuleFunction
+    extend self
+    # rubocop:enable Style/ModuleFunction
   end
 end

--- a/lib/filewatcher/spec_helper/watch_run.rb
+++ b/lib/filewatcher/spec_helper/watch_run.rb
@@ -1,16 +1,12 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-
 class Filewatcher
   module SpecHelper
     ## Base class for Filewatcher runners in specs
     class WatchRun
-      extend Forwardable
+      include Filewatcher::SpecHelper
 
       TMP_DIR = "#{Dir.getwd}/spec/tmp"
-
-      def_delegators Filewatcher::SpecHelper, :debug, :wait, :system_stat
 
       attr_reader :filename
 


### PR DESCRIPTION
See mentioned discussion.
Also it's more flexible with constants (blocks can be pretty huge).