### PR TITLE
Fix syntax for rubocop

### DIFF
--- a/lib/filewatcher/spec_helper/watch_run.rb
+++ b/lib/filewatcher/spec_helper/watch_run.rb
@@ -12,8 +12,10 @@ class Filewatcher
 
       def initialize(filename:, action:, directory:)
         @filename =
-          if filename.match? %r{^(/|~|[A-Z]:)} then filename
-          else File.join(TMP_DIR, filename)
+          if filename.match? %r{^(/|~|[A-Z]:)}
+            filename
+          else
+            File.join(TMP_DIR, filename)
           end
         @directory = directory
         @action = action


### PR DESCRIPTION
### Description:
@thomasfl / @AlexWayfer CI started failing in September for a rubocop formatting offense: 
_From [Cirrus Logs](https://cirrus-ci.com/task/5973041466310656?logs=lint#L6-L6)_
```console
bundle exec rubocop
Inspecting 15 files
........W......
Offenses:
lib/filewatcher/spec_helper/watch_run.rb:16:16: W: [Correctable] Lint/ElseLayout: Odd else layout detected. Did you mean to use elsif?
          else File.join(TMP_DIR, filename)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
15 files inspected, 1 offense detected, 1 offense auto-correctable
```

This PR just makes a small tweak to the formatting of the line in question to make rubocop happy again:
```console
bundle exec rubocop
Inspecting 15 files
...............

15 files inspected, no offenses detected
```

### Testing:
All tests should continue to pass