### PR TITLE
Change Bundler update approach for CI

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -130,7 +130,7 @@ test_task:
           ## But I don't know what to do with cache and new versions (`upgrade`?)
           - choco install ruby -y --no-progress --params "/NoPath /InstallDir:%RUBY_PATH%"
 
-          - gem install bundler
+          - gem update --system --no-document
 
       bundle_cache:
         folder: vendor\bundle


### PR DESCRIPTION
There were errors in Windows:

```
C:\Users\ContainerAdministrator\AppData\Local\Temp\cirrus-ci-build>call gem install bundler
ERROR:  Error installing bundler:
"bundle" from bundler conflicts with C:/tools/ruby/bin/bundle
```