### PR TITLE
Try to fix macOS CI

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -142,7 +142,8 @@ test_task:
 
       test_script: bundle exec rspec
 
-      <<: *unix_codecov
+      ## https://github.com/codecov/uploader/issues/523#issuecomment-1318842102
+      # <<: *unix_codecov
 
     - windows_container:
         image: cirrusci/windowsservercore:2019

--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -117,7 +117,7 @@ test_task:
       <<: *unix_codecov
 
     - macos_instance:
-        image: monterey-base
+        image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
       env:
         RUBY_PATH: "/usr/local/opt/ruby"


### PR DESCRIPTION
There is a problem with `codecov` executable permissions, restored from the cache: https://github.com/cirruslabs/cirrus-ci-docs/issues/1087

But also try to migrate to new instances.