### PR TITLE
Add logger dependency

### DIFF
--- a/filewatcher.gemspec
+++ b/filewatcher.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.0', '< 4'
 
-  s.add_runtime_dependency 'module_methods', '~> 0.1.0'
+  s.add_dependency 'module_methods', '~> 0.1.0'
+  s.add_dependency 'logger', '~> 1.6'
 end


### PR DESCRIPTION
Ruby 3.3.5 started to issue a warning if logger is loaded from standard library.